### PR TITLE
KAD-608: add acc tests for physical pagination

### DIFF
--- a/lib/kadai-core/src/test/java/acceptance/ParameterizedQuerySqlCaptureInterceptor.java
+++ b/lib/kadai-core/src/test/java/acceptance/ParameterizedQuerySqlCaptureInterceptor.java
@@ -1,0 +1,33 @@
+package acceptance;
+
+import java.sql.Statement;
+import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Signature;
+
+@Intercepts({
+  @Signature(
+      type = StatementHandler.class,
+      method = "parameterize",
+      args = {Statement.class})
+})
+public class ParameterizedQuerySqlCaptureInterceptor implements Interceptor {
+
+  private static String capturedSql;
+
+  @Override
+  public Object intercept(Invocation invocation) throws Throwable {
+    final StatementHandler statementHandler = (StatementHandler) invocation.getTarget();
+    final BoundSql boundSql = statementHandler.getBoundSql();
+    capturedSql = boundSql.getSql();
+
+    return invocation.proceed();
+  }
+
+  public static String getCapturedSql() {
+    return capturedSql;
+  }
+}

--- a/lib/kadai-core/src/test/java/acceptance/classification/query/QueryClassificationsWithPaginationAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/classification/query/QueryClassificationsWithPaginationAccTest.java
@@ -1,0 +1,45 @@
+package acceptance.classification.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import acceptance.AbstractAccTest;
+import acceptance.ParameterizedQuerySqlCaptureInterceptor;
+import io.kadai.common.internal.KadaiEngineImpl;
+import java.lang.reflect.Field;
+import org.apache.ibatis.session.SqlSessionManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class QueryClassificationsWithPaginationAccTest extends AbstractAccTest {
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class PhysicalPagination {
+
+    @BeforeAll
+    void setup() throws Exception {
+      Field sessionManagerField = KadaiEngineImpl.class.getDeclaredField("sessionManager");
+      sessionManagerField.setAccessible(true);
+      SqlSessionManager sessionManager = (SqlSessionManager) sessionManagerField.get(kadaiEngine);
+      sessionManager
+          .getConfiguration()
+          .addInterceptor(new ParameterizedQuerySqlCaptureInterceptor());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,10", "5,10", "0,0", "2,4"})
+    void should_UseNativeSql_For_QueryPagination(int offset, int limit) {
+      kadaiEngine.getClassificationService().createClassificationQuery().list(offset, limit);
+      final String sql = ParameterizedQuerySqlCaptureInterceptor.getCapturedSql();
+      final String physicalPattern1 = String.format("LIMIT %d OFFSET %d", limit, offset);
+      final String physicalPattern2 =
+          String.format("OFFSET %d ROWS FETCH FIRST %d ROWS ONLY", limit, offset);
+
+      assertThat(sql).containsAnyOf(physicalPattern1, physicalPattern2);
+    }
+  }
+}

--- a/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksWithPaginationAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/task/query/QueryTasksWithPaginationAccTest.java
@@ -22,6 +22,7 @@ import static io.kadai.common.api.BaseQuery.SortDirection.DESCENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import acceptance.AbstractAccTest;
+import acceptance.ParameterizedQuerySqlCaptureInterceptor;
 import io.kadai.common.api.KeyDomain;
 import io.kadai.common.internal.KadaiEngineImpl;
 import io.kadai.common.test.security.JaasExtension;
@@ -29,8 +30,6 @@ import io.kadai.common.test.security.WithAccessId;
 import io.kadai.task.api.TaskQuery;
 import io.kadai.task.api.TaskService;
 import io.kadai.task.api.models.TaskSummary;
-
-import acceptance.ParameterizedQuerySqlCaptureInterceptor;
 import java.lang.reflect.Field;
 import java.util.List;
 import org.apache.ibatis.session.SqlSessionManager;

--- a/lib/kadai-core/src/test/java/acceptance/user/query/QueryUsersWithPaginationAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/user/query/QueryUsersWithPaginationAccTest.java
@@ -1,0 +1,45 @@
+package acceptance.user.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import acceptance.AbstractAccTest;
+import acceptance.ParameterizedQuerySqlCaptureInterceptor;
+import io.kadai.common.internal.KadaiEngineImpl;
+import java.lang.reflect.Field;
+import org.apache.ibatis.session.SqlSessionManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class QueryUsersWithPaginationAccTest extends AbstractAccTest {
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class PhysicalPagination {
+
+    @BeforeAll
+    void setup() throws Exception {
+      Field sessionManagerField = KadaiEngineImpl.class.getDeclaredField("sessionManager");
+      sessionManagerField.setAccessible(true);
+      SqlSessionManager sessionManager = (SqlSessionManager) sessionManagerField.get(kadaiEngine);
+      sessionManager
+          .getConfiguration()
+          .addInterceptor(new ParameterizedQuerySqlCaptureInterceptor());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,10", "5,10", "0,0", "2,4"})
+    void should_UseNativeSql_For_QueryPagination(int offset, int limit) {
+      kadaiEngine.getUserService().createUserQuery().list(offset, limit);
+      final String sql = ParameterizedQuerySqlCaptureInterceptor.getCapturedSql();
+      final String physicalPattern1 = String.format("LIMIT %d OFFSET %d", limit, offset);
+      final String physicalPattern2 =
+          String.format("OFFSET %d ROWS FETCH FIRST %d ROWS ONLY", limit, offset);
+
+      assertThat(sql).containsAnyOf(physicalPattern1, physicalPattern2);
+    }
+  }
+}

--- a/lib/kadai-core/src/test/java/acceptance/workbasket/query/QueryWorkbasketsWithPaginationAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/workbasket/query/QueryWorkbasketsWithPaginationAccTest.java
@@ -21,14 +21,12 @@ package acceptance.workbasket.query;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import acceptance.AbstractAccTest;
-
+import acceptance.ParameterizedQuerySqlCaptureInterceptor;
 import io.kadai.common.internal.KadaiEngineImpl;
 import io.kadai.common.test.security.JaasExtension;
 import io.kadai.common.test.security.WithAccessId;
 import io.kadai.workbasket.api.WorkbasketService;
 import io.kadai.workbasket.api.models.WorkbasketSummary;
-
-import acceptance.ParameterizedQuerySqlCaptureInterceptor;
 import java.lang.reflect.Field;
 import java.util.List;
 import org.apache.ibatis.session.SqlSessionManager;

--- a/lib/kadai-core/src/test/java/acceptance/workbasket/query/QueryWorkbasketsWithPaginationAccTest.java
+++ b/lib/kadai-core/src/test/java/acceptance/workbasket/query/QueryWorkbasketsWithPaginationAccTest.java
@@ -21,13 +21,25 @@ package acceptance.workbasket.query;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import acceptance.AbstractAccTest;
+
+import io.kadai.common.internal.KadaiEngineImpl;
 import io.kadai.common.test.security.JaasExtension;
 import io.kadai.common.test.security.WithAccessId;
 import io.kadai.workbasket.api.WorkbasketService;
 import io.kadai.workbasket.api.models.WorkbasketSummary;
+
+import acceptance.ParameterizedQuerySqlCaptureInterceptor;
+import java.lang.reflect.Field;
 import java.util.List;
+import org.apache.ibatis.session.SqlSessionManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /** Acceptance test for all "query classifications with pagination" scenarios. */
 @ExtendWith(JaasExtension.class)
@@ -171,5 +183,32 @@ class QueryWorkbasketsWithPaginationAccTest extends AbstractAccTest {
     List<WorkbasketSummary> result =
         workbasketService.createWorkbasketQuery().domainIn("DOMAIN_A").list();
     assertThat(result).hasSize(9);
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  class PhysicalPagination {
+
+    @BeforeAll
+    void setup() throws Exception {
+      Field sessionManagerField = KadaiEngineImpl.class.getDeclaredField("sessionManager");
+      sessionManagerField.setAccessible(true);
+      SqlSessionManager sessionManager = (SqlSessionManager) sessionManagerField.get(kadaiEngine);
+      sessionManager
+          .getConfiguration()
+          .addInterceptor(new ParameterizedQuerySqlCaptureInterceptor());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,10", "5,10", "0,0", "2,4"})
+    void should_UseNativeSql_For_QueryPagination(int offset, int limit) {
+      kadaiEngine.getWorkbasketService().createWorkbasketQuery().list(offset, limit);
+      final String sql = ParameterizedQuerySqlCaptureInterceptor.getCapturedSql();
+      final String physicalPattern1 = String.format("LIMIT %d OFFSET %d", limit, offset);
+      final String physicalPattern2 =
+          String.format("OFFSET %d ROWS FETCH FIRST %d ROWS ONLY", limit, offset);
+
+      assertThat(sql).containsAnyOf(physicalPattern1, physicalPattern2);
+    }
   }
 }


### PR DESCRIPTION
Here are the acceptance tests for querying tasks, workbaskets, classifications and users.
Apart from the latter, they all work.

For users the query does not seem to be rewritten - the test fails and I confirmed by checking the debug log.
I guess the `PaginationInterceptor` doesnt't fire there.
